### PR TITLE
Update rq.py

### DIFF
--- a/Xlib/protocol/rq.py
+++ b/Xlib/protocol/rq.py
@@ -604,7 +604,8 @@ class Object(ValueField):
         return self.type.parse_value(val, display)
 
     def pack_value(self, val):
-        return self.type.pack_value(val)
+        val = self.type.pack_value(val)
+        return val, len(val), None
 
     def check_value(self, val):
         if isinstance(val, tuple):


### PR DESCRIPTION
Fixes return type inconsistency with the `pack_value` for class `Object`.
When using an `Object` field embedded in a request `pack_value` croaks because it calls to_binary which returns a byte buffer instead of a
3-value tuple. This fix addresses the issue.